### PR TITLE
Update schemas to include multicurrency fields

### DIFF
--- a/tap_quickbooks/schemas/accounts.json
+++ b/tap_quickbooks/schemas/accounts.json
@@ -57,12 +57,6 @@
         "string"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "AccountType": {
       "type": [
         "null",

--- a/tap_quickbooks/schemas/bill_payments.json
+++ b/tap_quickbooks/schemas/bill_payments.json
@@ -219,11 +219,12 @@
         "string"
       ]
     },
-    "sparse": {
+    "ExchangeRate": {
       "type": [
         "null",
-        "boolean"
-      ]
+        "string"
+      ],
+      "format": "singer.decimal"
     }
   }
 }

--- a/tap_quickbooks/schemas/bills.json
+++ b/tap_quickbooks/schemas/bills.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "CurrencyRef": {
       "properties": {
         "name": {
@@ -332,6 +326,33 @@
         "null",
         "string"
       ]
+    },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "DepartmentRef": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "value": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
     },
     "SalesTermRef": {
       "properties": {

--- a/tap_quickbooks/schemas/budgets.json
+++ b/tap_quickbooks/schemas/budgets.json
@@ -125,12 +125,6 @@
         "null",
         "object"
       ]
-    },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
     }
   },
   "type": [

--- a/tap_quickbooks/schemas/classes.json
+++ b/tap_quickbooks/schemas/classes.json
@@ -63,12 +63,6 @@
         "null",
         "string"
       ]
-    },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
     }
   },
   "type": [

--- a/tap_quickbooks/schemas/credit_memos.json
+++ b/tap_quickbooks/schemas/credit_memos.json
@@ -190,12 +190,6 @@
         "boolean"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "domain": {
       "type": [
         "null",
@@ -385,6 +379,20 @@
       "type": [
         "null",
         "integer"
+      ]
+    },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "HomeTotalAmt": {
+      "format": "singer.decimal",
+      "type": [
+        "null",
+        "string"
       ]
     },
     "MetaData": {

--- a/tap_quickbooks/schemas/customers.json
+++ b/tap_quickbooks/schemas/customers.json
@@ -195,12 +195,6 @@
         "object"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "PreferredDeliveryMethod": {
       "type": [
         "null",

--- a/tap_quickbooks/schemas/departments.json
+++ b/tap_quickbooks/schemas/departments.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "MetaData": {
       "properties": {
         "LastUpdatedTime": {

--- a/tap_quickbooks/schemas/deposits.json
+++ b/tap_quickbooks/schemas/deposits.json
@@ -20,12 +20,6 @@
         "object"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "CashBack": {
       "properties": {
         "AccountRef": {
@@ -259,6 +253,13 @@
         "null",
         "string"
       ]
+    },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
     },
     "PrivateNote": {
       "type": [

--- a/tap_quickbooks/schemas/employees.json
+++ b/tap_quickbooks/schemas/employees.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "HiredDate": {
       "format": "date-time",
       "type": [

--- a/tap_quickbooks/schemas/estimates.json
+++ b/tap_quickbooks/schemas/estimates.json
@@ -14,12 +14,6 @@
         "object"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "BillAddr": {
       "properties": {
         "Lat": {
@@ -476,6 +470,20 @@
       "type": [
         "null",
         "array"
+      ]
+    },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "HomeTotalAmt": {
+      "format": "singer.decimal",
+      "type": [
+        "null",
+        "string"
       ]
     },
     "ShipAddr": {

--- a/tap_quickbooks/schemas/invoices.json
+++ b/tap_quickbooks/schemas/invoices.json
@@ -28,6 +28,18 @@
     },
     "BillAddr": {
       "properties": {
+        "CountrySubDivisionCode": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "City": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "Line3": {
           "type": [
             "null",
@@ -53,6 +65,12 @@
           ]
         },
         "Line4": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "PostalCode": {
           "type": [
             "null",
             "string"
@@ -106,12 +124,6 @@
       "type": [
         "null",
         "string"
-      ]
-    },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
       ]
     },
     "DeliveryInfo": {
@@ -261,6 +273,20 @@
         "string"
       ]
     },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "HomeTotalAmt": {
+      "format": "singer.decimal",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "Line": {
       "items": {
         "properties": {
@@ -305,6 +331,26 @@
           },
           "SalesItemLineDetail": {
             "properties": {
+              "ClassRef": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "properties": {
+                  "name": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              },
               "TaxCodeRef": {
                 "properties": {
                   "value": {

--- a/tap_quickbooks/schemas/items.json
+++ b/tap_quickbooks/schemas/items.json
@@ -101,12 +101,6 @@
         "boolean"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "AssetAccountRef": {
       "properties": {
         "name": {

--- a/tap_quickbooks/schemas/journal_entries.json
+++ b/tap_quickbooks/schemas/journal_entries.json
@@ -32,12 +32,6 @@
         "string"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "SyncToken": {
       "type": [
         "null",
@@ -129,6 +123,13 @@
         "null",
         "string"
       ]
+    },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
     },
     "MetaData": {
       "properties": {

--- a/tap_quickbooks/schemas/payment_methods.json
+++ b/tap_quickbooks/schemas/payment_methods.json
@@ -44,12 +44,6 @@
         "string"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "SyncToken": {
       "type": [
         "null",

--- a/tap_quickbooks/schemas/payments.json
+++ b/tap_quickbooks/schemas/payments.json
@@ -181,6 +181,13 @@
         "string"
       ]
     },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
     "TotalAmt": {
       "type": [
         "null",
@@ -259,12 +266,6 @@
       "type": [
         "null",
         "string"
-      ]
-    },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
       ]
     },
     "PaymentMethodRef": {

--- a/tap_quickbooks/schemas/purchase_orders.json
+++ b/tap_quickbooks/schemas/purchase_orders.json
@@ -44,12 +44,6 @@
         }
       }
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "Id": {
       "type": [
         "null",
@@ -175,6 +169,18 @@
             "string"
           ]
         },
+        "City": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "Country": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "Line1": {
           "type": [
             "null",
@@ -243,6 +249,13 @@
         }
       }
     },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
     "TotalAmt": {
       "type": [
         "null",
@@ -288,6 +301,26 @@
         "null",
         "string"
       ]
+    },
+    "DepartmentRef": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "value": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
     },
     "Line": {
       "type": [
@@ -336,6 +369,26 @@
                   "null",
                   "string"
                 ]
+              },
+              "ClassRef": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "properties": {
+                  "name": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
               },
               "ItemRef": {
                 "type": [

--- a/tap_quickbooks/schemas/purchases.json
+++ b/tap_quickbooks/schemas/purchases.json
@@ -108,6 +108,13 @@
         }
       }
     },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
     "TotalAmt": {
       "type": [
         "null",
@@ -448,12 +455,6 @@
       "type": [
         "null",
         "string"
-      ]
-    },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
       ]
     }
   }

--- a/tap_quickbooks/schemas/refund_receipts.json
+++ b/tap_quickbooks/schemas/refund_receipts.json
@@ -34,12 +34,6 @@
         "object"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "CustomerRef": {
       "properties": {
         "name": {
@@ -379,6 +373,20 @@
       "type": [
         "null",
         "boolean"
+      ]
+    },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "HomeTotalAmt": {
+      "format": "singer.decimal",
+      "type": [
+        "null",
+        "string"
       ]
     },
     "TotalAmt": {

--- a/tap_quickbooks/schemas/sales_receipts.json
+++ b/tap_quickbooks/schemas/sales_receipts.json
@@ -493,10 +493,18 @@
         }
       }
     },
-    "sparse": {
+    "ExchangeRate": {
       "type": [
         "null",
-        "boolean"
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "HomeTotalAmt": {
+      "format": "singer.decimal",
+      "type": [
+        "null",
+        "string"
       ]
     },
     "TotalAmt": {

--- a/tap_quickbooks/schemas/tax_agencies.json
+++ b/tap_quickbooks/schemas/tax_agencies.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "Id": {
       "type": [
         "null",

--- a/tap_quickbooks/schemas/tax_codes.json
+++ b/tap_quickbooks/schemas/tax_codes.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "TaxGroup": {
       "type": [
         "null",

--- a/tap_quickbooks/schemas/tax_rates.json
+++ b/tap_quickbooks/schemas/tax_rates.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "SpecialTaxType": {
       "type": [
         "null",

--- a/tap_quickbooks/schemas/terms.json
+++ b/tap_quickbooks/schemas/terms.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "Id": {
       "type": [
         "null",

--- a/tap_quickbooks/schemas/time_activities.json
+++ b/tap_quickbooks/schemas/time_activities.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "HourlyRate": {
       "type": [
         "null",

--- a/tap_quickbooks/schemas/transfers.json
+++ b/tap_quickbooks/schemas/transfers.json
@@ -6,12 +6,6 @@
         "string"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "MetaData": {
       "properties": {
         "LastUpdatedTime": {
@@ -52,6 +46,13 @@
         "null",
         "string"
       ]
+    },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
     },
     "Amount": {
       "type": [

--- a/tap_quickbooks/schemas/vendor_credits.json
+++ b/tap_quickbooks/schemas/vendor_credits.json
@@ -22,6 +22,13 @@
         "object"
       ]
     },
+    "ExchangeRate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
     "TotalAmt": {
       "type": [
         "null",
@@ -39,12 +46,6 @@
       "type": [
         "null",
         "string"
-      ]
-    },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
       ]
     },
     "VendorRef": {

--- a/tap_quickbooks/schemas/vendors.json
+++ b/tap_quickbooks/schemas/vendors.json
@@ -273,12 +273,6 @@
         "boolean"
       ]
     },
-    "sparse": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "Title": {
       "type": [
         "null",

--- a/tests/test_quickbooks_bookmarks.py
+++ b/tests/test_quickbooks_bookmarks.py
@@ -48,7 +48,7 @@ class TestQuickbooksBookmarks(TestQuickbooksBase):
 
         # Verify the bookmark is correct, LastUpdatedTime assumes no other Account records are added to Sandbox
         actual_state = menagerie.get_state(conn_id)
-        expected_state = {'bookmarks': {'accounts': {'LastUpdatedTime': '2020-08-24T08:44:33-07:00'}}}
+        expected_state = {'bookmarks': {'accounts': {'LastUpdatedTime': '2020-08-25T13:17:37-07:00'}}}
         self.assertEqual(actual_state, expected_state)
 
         # Verify actual rows were synced

--- a/tests/test_quickbooks_bookmarks.py
+++ b/tests/test_quickbooks_bookmarks.py
@@ -62,7 +62,7 @@ class TestQuickbooksBookmarks(TestQuickbooksBase):
                 self.assertGreaterEqual(sync_record_count[stream], 1)
 
         # Update state and sync again
-        new_state = {'bookmarks': {'accounts': {'LastUpdatedTime': '2020-08-24T08:43:33-07:00'}}}
+        new_state = {'bookmarks': {'accounts': {'LastUpdatedTime': '2020-08-25T13:17:36-07:00'}}}
         menagerie.set_state(conn_id, new_state, version=1)
 
         sync_job_name = runner.run_sync_mode(self, conn_id)

--- a/tests/test_quickbooks_pagination.py
+++ b/tests/test_quickbooks_pagination.py
@@ -56,4 +56,4 @@ class TestQuickbooksPagination(TestQuickbooksBase):
             self, conn_id, self.expected_streams(), self.expected_primary_keys())
 
         # Examine target output
-        self.assertEqual(sync_record_count, {'accounts': 91})
+        self.assertEqual(sync_record_count, {'accounts': 92})

--- a/tests/test_quickbooks_start_date.py
+++ b/tests/test_quickbooks_start_date.py
@@ -63,7 +63,7 @@ class TestQuickbooksStartDate(TestQuickbooksBase):
             self, conn_id, self.expected_streams(), self.expected_primary_keys())
 
         # Examine target output
-        self.assertEqual(sync_record_count, {'accounts': 91})
+        self.assertEqual(sync_record_count, {'accounts': 92})
 
         conn_id = self.ensure_connection(original=False)
         # Run in check mode
@@ -78,4 +78,4 @@ class TestQuickbooksStartDate(TestQuickbooksBase):
         # Verify only 1 record synced with the new state
         sync_record_count = runner.examine_target_output_file(
             self, conn_id, self.expected_streams(), self.expected_primary_keys())
-        self.assertEqual(sync_record_count, {'accounts': 1})
+        self.assertEqual(sync_record_count, {'accounts': 3})


### PR DESCRIPTION
# Description of change
There are quickbooks fields that are only returned if multicurrency is enabled. Add these to the schema.

Also remove sparse. That is metadata about the query that has no use for the tap.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
