### PR TITLE
Use the state on the class correctly

### DIFF
--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -32,14 +32,14 @@ class Stream:
                 yield rec
 
             if results:
-                state = singer.write_bookmark(self.state, self.stream_name, 'LastUpdatedTime', rec.get('MetaData').get('LastUpdatedTime'))
-                singer.write_state(state)
+                self.state = singer.write_bookmark(self.state, self.stream_name, 'LastUpdatedTime', rec.get('MetaData').get('LastUpdatedTime'))
+                singer.write_state(self.state)
 
             if len(results) < max_results:
                 break
             start_position += max_results
 
-        singer.write_state(state)
+        singer.write_state(self.state)
 
 
 


### PR DESCRIPTION
# Description of change
We were not using the state on the object correctly and were instead creating a local variable to store it, causing problems if there were no records

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
