### PR TITLE
Add active flag for streams that use it and test all streams where possible

### DIFF
--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -48,25 +48,17 @@ class Accounts(Stream):
     additional_where = "Active IN (true, false)"
 
 
-class Invoices(Stream):
-    stream_name = 'invoices'
-    table_name = 'Invoice'
-
-
-class Items(Stream):
-    stream_name = 'items'
-    table_name = 'Item'
-    additional_where = "Active IN (true, false)"
-
 class Budgets(Stream):
     stream_name = 'budgets'
     table_name = 'Budget'
     additional_where = "Active IN (true, false)"
 
+
 class Classes(Stream):
     stream_name = 'classes'
     table_name = 'Class'
     additional_where = "Active IN (true, false)"
+
 
 class CreditMemos(Stream):
     stream_name = 'credit_memos'
@@ -204,27 +196,25 @@ class Vendors(Stream):
 
 STREAM_OBJECTS = {
     "accounts": Accounts,
-    "invoices": Invoices,
-    "items": Items,
+    "bill_payments": BillPayments,
+    "bills": Bills,
     "budgets": Budgets,
     "classes": Classes,
     "credit_memos": CreditMemos,
-    "bill_payments": BillPayments,
-    "sales_receipts": SalesReceipts,
-    "purchases": Purchases,
-    "payments": Payments,
-    "purchase_orders": PurchaseOrders,
-    "payment_methods": PaymentMethods,
-    "journal_entries": JournalEntries,
-    "items": Items,
-    "invoices": Invoices,
     "customers": Customers,
-    "refund_receipts": RefundReceipts,
-    "deposits": Deposits,
     "departments": Departments,
+    "deposits": Deposits,
     "employees": Employees,
     "estimates": Estimates,
-    "bills": Bills,
+    "invoices": Invoices,
+    "items": Items,
+    "journal_entries": JournalEntries,
+    "payment_methods": PaymentMethods,
+    "payments": Payments,
+    "purchase_orders": PurchaseOrders,
+    "purchases": Purchases,
+    "refund_receipts": RefundReceipts,
+    "sales_receipts": SalesReceipts,
     "tax_agencies": TaxAgencies,
     "tax_codes": TaxCodes,
     "tax_rates": TaxRates,

--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -42,7 +42,6 @@ class Stream:
         singer.write_state(self.state)
 
 
-
 class Accounts(Stream):
     stream_name = 'accounts'
     table_name = 'Account'

--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -57,17 +57,17 @@ class Invoices(Stream):
 class Items(Stream):
     stream_name = 'items'
     table_name = 'Item'
-
+    additional_where = "Active IN (true, false)"
 
 class Budgets(Stream):
     stream_name = 'budgets'
     table_name = 'Budget'
-
+    additional_where = "Active IN (true, false)"
 
 class Classes(Stream):
     stream_name = 'classes'
     table_name = 'Class'
-
+    additional_where = "Active IN (true, false)"
 
 class CreditMemos(Stream):
     stream_name = 'credit_memos'
@@ -102,83 +102,105 @@ class PurchaseOrders(Stream):
 class PaymentMethods(Stream):
     stream_name = 'payment_methods'
     table_name = 'PaymentMethod'
-
+    additional_where = "Active IN (true, false)"
 
 
 class JournalEntries(Stream):
     stream_name = 'journal_entries'
     table_name = 'JournalEntry'
 
+
 class Items(Stream):
     stream_name = 'items'
     table_name = 'Item'
     additional_where = "Active IN (true, false)"
 
+
 class Invoices(Stream):
     stream_name = 'invoices'
     table_name = 'Invoice'
+
 
 class Customers(Stream):
     stream_name = 'customers'
     table_name = 'Customer'
     additional_where = "Active IN (true, false)"
 
+
 class RefundReceipts(Stream):
     stream_name = 'refund_receipts'
     table_name = 'RefundReceipt'
+
 
 class Deposits(Stream):
     stream_name = 'deposits'
     table_name = 'Deposit'
 
+
 class Departments(Stream):
     stream_name = 'departments'
     table_name = 'Department'
+    additional_where = "Active IN (true, false)"
+
 
 class Employees(Stream):
     stream_name = 'employees'
     table_name = 'Employee'
     additional_where = "Active IN (true, false)"
 
+
 class Estimates(Stream):
     stream_name = 'estimates'
     table_name = 'Estimate'
+
 
 class Bills(Stream):
     stream_name = 'bills'
     table_name = 'Bill'
 
+
 class TaxAgencies(Stream):
     stream_name = 'tax_agencies'
     table_name = 'TaxAgency'
 
+
 class TaxCodes(Stream):
     stream_name = 'tax_codes'
     table_name = 'TaxCode'
+    additional_where = "Active IN (true, false)"
+
 
 class TaxRates(Stream):
     stream_name = 'tax_rates'
     table_name = 'TaxRate'
+    additional_where = "Active IN (true, false)"
+
 
 class Terms(Stream):
     stream_name = 'terms'
     table_name = 'Term'
+    additional_where = "Active IN (true, false)"
+
 
 class TimeActivities(Stream):
     stream_name = 'time_activities'
     table_name = 'TimeActivity'
 
+
 class Transfers(Stream):
     stream_name = 'transfers'
     table_name = 'Transfer'
+
 
 class VendorCredits(Stream):
     stream_name = 'vendor_credits'
     table_name = 'VendorCredit'
 
+
 class Vendors(Stream):
     stream_name = 'vendors'
     table_name = 'Vendor'
+    additional_where = "Active IN (true, false)"
 
 
 STREAM_OBJECTS = {

--- a/tests/base.py
+++ b/tests/base.py
@@ -55,27 +55,25 @@ class TestQuickbooksBase(unittest.TestCase):
     def expected_check_streams():
         return {
             "accounts",
-            "invoices",
-            "items",
+            "bill_payments",
+            "bills",
             "budgets",
             "classes",
             "credit_memos",
-            "bill_payments",
-            "sales_receipts",
-            "purchases",
-            "payments",
-            "purchase_orders",
-            "payment_methods",
-            "journal_entries",
-            "items",
-            "invoices",
             "customers",
-            "refund_receipts",
-            "deposits",
             "departments",
+            "deposits",
             "employees",
             "estimates",
-            "bills",
+            "invoices",
+            "items",
+            "journal_entries",
+            "payment_methods",
+            "payments",
+            "purchase_orders",
+            "purchases",
+            "refund_receipts",
+            "sales_receipts",
             "tax_agencies",
             "tax_codes",
             "tax_rates",
@@ -203,12 +201,17 @@ class TestQuickbooksBase(unittest.TestCase):
 
         see their docs for more info:
         https://developer.intuit.com/app/developer/qbo/docs/develop/sandboxes#launch-a-sandbox
+
+        For the remaining streams at least 1 record existed already, or 1 has been added.
         """
-        return {
-            "accounts": 90,
-            "customers": 29,
-            "employees": 2,
-            "items": 18,
-            # "transactions": 141, # TODO this is not a stream...what streams fall under this?
-            "vendors": 26,
-        }
+        # All streams should have at least a record (thi)
+        record_counts = {stream: 1 for stream in self.expected_check_streams()}
+
+        # By default quickbooks sandbox apps come with the following records
+        record_counts["accounts"]= 90
+        record_counts["customers"] = 29
+        record_counts["employees"] = 2
+        record_counts["items"] = 18
+        record_counts["vendors"] = 26
+
+        return record_counts

--- a/tests/test_quickbooks_automatic_fields.py
+++ b/tests/test_quickbooks_automatic_fields.py
@@ -26,17 +26,15 @@ class TestQuickbooksAutomaticFields(TestQuickbooksBase):
         return {
             'start_date' : '2016-06-02T00:00:00Z',
             'sandbox': 'true',
-            page_size_key: '10' # TODO can we add enough data per stream to test the default max_results (200)?
+            page_size_key: '10'
         }
 
     def expected_streams(self):
-        return {
-            'accounts',
-            'customers',
-            'employees',
-            'items',
-            'vendors',
-        }
+        """
+        All streams are under test with the exception of 'budgets' which
+        has a workaround to skip the invalid assertion.
+        """
+        return self.expected_check_streams()
 
 
     def test_run(self):
@@ -105,6 +103,11 @@ class TestQuickbooksAutomaticFields(TestQuickbooksBase):
 
                 # Verify the sync meets or exceeds the default record count
                 self.assertLessEqual(expected_count, record_count)
+
+                if stream == 'budgets': # Skip the pagination assertion for this stream
+                    # This stream returns a single record of the current budget state
+                    # and will never exceed our pagination size (max_results) in this test
+                    continue
 
                 # Verify the number or records exceeds the max_results (api limit)
                 pagination_threshold = int(self.get_properties().get(page_size_key))

--- a/tests/test_quickbooks_pagination.py
+++ b/tests/test_quickbooks_pagination.py
@@ -11,13 +11,14 @@ class TestQuickbooksPagination(TestQuickbooksBase):
         return "tap_tester_quickbooks_combined_test"
 
     def expected_streams(self):
-        return {
-            'accounts',
-            'customers',
-            'employees',
-            'items',
-            'vendors',
-        }
+        """
+        All streams except 'budgets' are under test. The 'budgets' stream
+        returns a single record of the current budget state and will never exceed
+        our pagination size (max_results) for this test.
+        """
+        return self.expected_check_streams().difference({
+            'budgets' # TODO verify this is just a standard report and will only ever generate a single record
+        })
 
     def get_properties(self):
         return {

--- a/tests/test_quickbooks_start_date.py
+++ b/tests/test_quickbooks_start_date.py
@@ -11,11 +11,33 @@ class TestQuickbooksStartDate(TestQuickbooksBase):
     def expected_streams(self):
         """Test coverage for this test. If the stream is here, we test it."""
         return {
-            'accounts',
-            'customers',
-            'employees',
-            'items',
-            'vendors'
+            "accounts",
+            "bill_payments",
+            "bills",
+            "classes",
+            "credit_memos",
+            "customers",
+            "departments",
+            "deposits",
+            "employees",
+            "estimates",
+            "invoices",
+            "items",
+            "journal_entries",
+            "payment_methods",
+            "payments",
+            "purchase_orders",
+            "purchases",
+            "refund_receipts",
+            "sales_receipts",
+            "tax_agencies",
+            "tax_codes",
+            "tax_rates",
+            "terms",
+            "time_activities",
+            "transfers",
+            "vendor_credits",
+            "vendors",
         }
 
     def get_properties(self, original=True):

--- a/tests/test_quickbooks_start_date.py
+++ b/tests/test_quickbooks_start_date.py
@@ -9,36 +9,8 @@ class TestQuickbooksStartDate(TestQuickbooksBase):
         return "tap_tester_quickbooks_combined_test"
 
     def expected_streams(self):
-        """Test coverage for this test. If the stream is here, we test it."""
-        return {
-            "accounts",
-            "bill_payments",
-            "bills",
-            "classes",
-            "credit_memos",
-            "customers",
-            "departments",
-            "deposits",
-            "employees",
-            "estimates",
-            "invoices",
-            "items",
-            "journal_entries",
-            "payment_methods",
-            "payments",
-            "purchase_orders",
-            "purchases",
-            "refund_receipts",
-            "sales_receipts",
-            "tax_agencies",
-            "tax_codes",
-            "tax_rates",
-            "terms",
-            "time_activities",
-            "transfers",
-            "vendor_credits",
-            "vendors",
-        }
+        """All streams are under test"""
+        return self.expected_check_streams()
 
     def get_properties(self, original=True):
         if original:


### PR DESCRIPTION
# Description of change
Active flag added to query for several streams.
Removed duplicate streams for tap's `streams.py`.
All streams added to following feature tests:
 - Start Date
 - Automatic Fields
 - Pagination

# Manual QA steps
 - Verified record counts increased when active flag was attached to new stream with a deleted object.
 - Verified record count stayed the same when active flag was added to new stream without a deleted object.
 - Created more data in UI and API Explorer to satisfy pagination requirement (record count >= 11 ) in order to test

# Risks
 - It is possible more streams use the Active flag but we are subject to accuracy of Quickbooks Docs.
 
# Rollback steps
 - revert this branch
