### PR TITLE
Remove extra `string` in purchase_orders & customers schemas

### DIFF
--- a/tap_quickbooks/schemas/customers.json
+++ b/tap_quickbooks/schemas/customers.json
@@ -61,7 +61,6 @@
         "Long": {
           "type": [
             "null",
-            "string",
             "string"
           ]
         },
@@ -284,7 +283,6 @@
         "Lat": {
           "type": [
             "null",
-            "string",
             "string"
           ]
         },
@@ -321,7 +319,6 @@
         "PostalCode": {
           "type": [
             "null",
-            "string",
             "string"
           ]
         },

--- a/tap_quickbooks/schemas/purchase_orders.json
+++ b/tap_quickbooks/schemas/purchase_orders.json
@@ -135,7 +135,6 @@
         "Long": {
           "type": [
             "null",
-            "string",
             "string"
           ]
         },


### PR DESCRIPTION
# Description of change
The `purchase_orders` and `customers` schemas have some properties with extra `type: string` values. This PR removes them.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
