### PR TITLE
bump to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.3
+
+* Added AcctNum and DocNumber fields
+
 ## 1.0.2
 
 * Fix EffectiveTaxRates issue in tax_rates schema

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-quickbooks',
-      version='1.0.2',
+      version='1.0.3',
       description='Singer.io tap for extracting data from the Quickbooks API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
Bump to 1.0.3, see https://github.com/singer-io/tap-quickbooks/pull/25

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
