### PR TITLE
TDL-14390: Added Deleted Objects stream to capture deleted entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This tap:
     * Transfers
     * VendorCredits
     * Vendors
+    * DeletedObjects
 
 - Includes a schema for each resource reflecting most recent tested data retrieved using the api. See [the schema folder](https://github.com/singer-io/tap-quickbooks/tree/master/tap_quickbooks/schemas) for details.
 - Incrementally pulls data based on the input state

--- a/tap_quickbooks/schemas/deleted_objects.json
+++ b/tap_quickbooks/schemas/deleted_objects.json
@@ -1,0 +1,42 @@
+{
+    "properties": {
+      "Type": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "domain": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "Id": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "MetaData": {
+        "properties": {
+          "LastUpdatedTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ]
+      }
+    },
+    "type": [
+      "null",
+      "object"
+    ]
+  }
+  

--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -198,37 +198,64 @@ class DeletedObjects(Stream):
     stream_name = 'deleted_objects'
     table_name = 'Deleted Objects'
     key_properties = ['Id', 'Type']
+    max_date = None
 
     # Change tracking is not supported for TimeActivities, TaxAgencies, TaxCodes and TaxRates
     # Reference: https://developer.intuit.com/app/developer/qbo/docs/develop/explore-the-quickbooks-online-api/change-data-capture
-    entities = ['Account', 'BillPayment', 'Bill', 'Budget', 'Class', 'CreditMemo',
-                'Customer', 'Department', 'Deposit', 'Employee', 'Estimate', 'Invoice',
-                'Item', 'JournalEntry', 'PaymentMethod', 'Payment', 'PurchaseOrder', 'Purchase',
-                'RefundReceipt', 'SalesReceipt', 'Term', 'Transfer', 'VendorCredit', 'Vendor']
-  
+    deleted_entities = ['Account', 'BillPayment', 'Bill', 'Budget', 'Class', 'CreditMemo',
+                        'Customer', 'Department', 'Deposit', 'Employee', 'Estimate', 'Invoice',
+                        'Item', 'JournalEntry', 'PaymentMethod', 'Payment', 'PurchaseOrder', 'Purchase',
+                        'RefundReceipt', 'SalesReceipt', 'Term', 'Transfer', 'VendorCredit', 'Vendor']
 
     def sync(self):
 
         bookmark = singer.get_bookmark(self.state, self.stream_name, 'LastUpdatedTime', self.config.get('start_date'))
-        max_date = bookmark
+        self.max_date = bookmark
         params = {
-            'entities': ','.join(self.entities),
+            'entities': ','.join(self.deleted_entities),
             'changedSince': bookmark
         }
 
+        # Get change tracking for all the entities in single call
         resp = self.client.get(self.endpoint, params=params).get('CDCResponse',[{}])[0].get('QueryResponse', [{}])
 
+        # Calculate number of objects found in response 
+        total_objects = 0
         for entities in resp:
+            for entity, values in entities.items():
+                if isinstance(values, list):
+                    total_objects += len(values)
+
+        # Change tracking API return maximum 1000 object changes. 
+        # So if objects are not less than 1000 then make individual call for every entity
+        # Reference: https://developer.intuit.com/app/developer/qbo/docs/develop/explore-the-quickbooks-online-api/change-data-capture
+
+        if total_objects < 1000:
+            yield from self.parse_data_and_write(resp)
+        else:
+            for entity in self.deleted_entities:
+                params = {
+                    'entities': entity,
+                    'changedSince': bookmark
+                }
+                resp = self.client.get(self.endpoint, params=params).get('CDCResponse',[{}])[0].get('QueryResponse', [{}])
+                yield from self.parse_data_and_write(resp)
+        
+        self.state = singer.write_bookmark(self.state, self.stream_name, 'LastUpdatedTime', self.max_date)
+        singer.write_state(self.state)
+
+    def parse_data_and_write(self, response):
+        '''
+            Parse change tracking response and return every deleted entity 
+        '''
+        for entities in response:
             for entity, values in entities.items():
                 if isinstance(values, list):
                     for rec in values:
                         if rec.get('status', None) == 'Deleted':
                             rec['Type'] = entity
-                            max_date = max(max_date, rec.get('MetaData').get('LastUpdatedTime'))
+                            self.max_date = max(self.max_date, rec.get('MetaData').get('LastUpdatedTime'))
                             yield rec
-
-        self.state = singer.write_bookmark(self.state, self.stream_name, 'LastUpdatedTime', max_date)
-        singer.write_state(self.state)
 
 
 STREAM_OBJECTS = {

--- a/tests/base.py
+++ b/tests/base.py
@@ -89,6 +89,7 @@ class TestQuickbooksBase(unittest.TestCase):
             "transfers",
             "vendor_credits",
             "vendors",
+            "deleted_objects"
         }
 
     def expected_metadata(self):
@@ -96,11 +97,18 @@ class TestQuickbooksBase(unittest.TestCase):
 
         mdata = {}
         for stream in self.expected_check_streams():
-            mdata[stream] = {
-                self.PRIMARY_KEYS: {'Id'},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {'MetaData'},
-            }
+            if stream == "deleted_objects":
+                mdata[stream] = {
+                    self.PRIMARY_KEYS: {'Id', 'Type'},
+                    self.REPLICATION_METHOD: self.INCREMENTAL,
+                    self.REPLICATION_KEYS: {'MetaData'},
+                }
+            else:
+                mdata[stream] = {
+                    self.PRIMARY_KEYS: {'Id'},
+                    self.REPLICATION_METHOD: self.INCREMENTAL,
+                    self.REPLICATION_KEYS: {'MetaData'},
+                }
 
         return mdata
 

--- a/tests/test_quickbooks_pagination.py
+++ b/tests/test_quickbooks_pagination.py
@@ -60,6 +60,8 @@ class TestQuickbooksPagination(TestQuickbooksBase):
 
         # Test by stream
         for stream in self.expected_streams():
+            if stream == "deleted_objects": # Deleted Objects stream does not have Pagination support
+                continue
             with self.subTest(stream=stream):
 
                 expected_count = self.minimum_record_count_by_stream().get(stream)


### PR DESCRIPTION
# Description of change
TDL-14390:  Investigate Change Tracking
- Added Deleted Object stream with ID, Entity Type, and updated time-related fields.
- QuickBooks change tracking does not support the below streams.
  - TimeActivities, TaxAgencies, TaxCodes, and TaxRates
  - Reference: https://developer.intuit.com/app/developer/qbo/docs/develop/explore-the-quickbooks-online-api/change-data-capture

# Manual QA steps
 - Verify that Deleted objects are emitted with ID and type in sync mode if a stream is selected.
 - Integration tests are passing for the Deleted Objects stream.
 
# Risks
 - No risk
 
# Rollback steps
 - revert this branch
