### PR TITLE
Tdl 13967 add profit loss report stream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             python3 -mvenv /usr/local/share/virtualenvs/tap-quickbooks
             source /usr/local/share/virtualenvs/tap-quickbooks/bin/activate
             pip install -U pip setuptools
-            pip install .[dev]
+            pip install .[test]
       - run:
           name: 'JSON Validator'
           command: |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This tap:
     * Transfers
     * VendorCredits
     * Vendors
+    * ProfitAndLossReport
 
 - Includes a schema for each resource reflecting most recent tested data retrieved using the api. See [the schema folder](https://github.com/singer-io/tap-quickbooks/tree/master/tap_quickbooks/schemas) for details.
 - Incrementally pulls data based on the input state

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,12 @@ setup(name='tap-quickbooks',
           'requests_oauthlib==1.3.0',
       ],
       extras_require={
-          'dev': [
-              'ipdb==0.11',
+          'test': [
               'pylint==2.5.3',
               'nose'
+          ],
+          'dev': [
+              'ipdb'
           ]
       },
       entry_points='''

--- a/tap_quickbooks/schemas/profit_loss_report.json
+++ b/tap_quickbooks/schemas/profit_loss_report.json
@@ -1,0 +1,28 @@
+{
+    "type": [
+      "null",
+      "object"
+    ],
+    "properties": {
+      "ReportDate": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "AccountingMethod": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "Details": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {}
+      }
+    }
+}

--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -311,14 +311,14 @@ class ReportStream(Stream):
         '''
             Return record for every day formed using output of parse_report_metadata
         '''
-        for i, date in enumerate(self.parsed_metadata['dates']):
+        for index, date in enumerate(self.parsed_metadata['dates']):
             report = dict()
             report['ReportDate'] = date
             report['AccountingMethod'] = 'Accrual'
             report['Details'] = {}
 
             for data in self.parsed_metadata['data']:
-                report['Details'][data['name']] = data['values'][i]
+                report['Details'][data['name']] = data['values'][index]
 
             yield report
 

--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -221,7 +221,7 @@ class ReportStream(Stream):
             start_dttm_str = self.config.get('start_date')
             is_start_date_used = True
 
-        # Set start_date and end_date for first date window of API calls
+        # Set start_date and end_date for first date window(30 days) of API calls
         start_dttm = strptime_to_utc(start_dttm_str)
         end_dttm = start_dttm + timedelta(days=DATE_WINDOW_SIZE)
         now_dttm = utils.now()
@@ -235,6 +235,7 @@ class ReportStream(Stream):
             if not is_start_date_used:
                 start_dttm = end_dttm - timedelta(days=DATE_WINDOW_SIZE)
 
+        # Make a API call in 30 days date window until reach current_time
         while start_dttm < now_dttm:
             self.parsed_metadata = {
                 'dates': [],
@@ -244,6 +245,7 @@ class ReportStream(Stream):
             start_tm_str = str(start_dttm.date())
             end_tm_str = str(end_dttm.date())
 
+            # Set date window
             params["start_date"] = start_tm_str
             params["end_date"] = end_tm_str
 

--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -255,7 +255,7 @@ class ReportStream(Stream):
                 self.state = singer.write_bookmark(self.state, self.stream_name, 'LastUpdatedTime', strptime_to_utc(report.get('ReportDate')).isoformat())
                 singer.write_state(self.state)
 
-            start_dttm = end_dttm
+            start_dttm = end_dttm + timedelta(days=1) # one record is emitted for every day so start from next day
             end_dttm = start_dttm + timedelta(days=DATE_WINDOW_SIZE)
 
             if end_dttm > now_dttm:

--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -239,8 +239,8 @@ class ReportStream(Stream):
                 'data': []
             }
 
-            start_tm_str = strftime(start_dttm)[0:10]
-            end_tm_str = strftime(end_dttm)[0:10]
+            start_tm_str = str(start_dttm.date())
+            end_tm_str = str(end_dttm.date())
 
             params["start_date"] = start_tm_str
             params["end_date"] = end_tm_str

--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -237,11 +237,12 @@ class ReportStream(Stream):
             resp = self.client.get(self.endpoint, params=params)
             self.parse_report_metadata(resp)
 
-            for report in self.day_wise_reports():
-                yield report
-
-            self.state = singer.write_bookmark(self.state, self.stream_name, 'LastUpdatedTime', strptime_to_utc(report.get('ReportDate')).isoformat())
-            singer.write_state(self.state)
+            reports = self.day_wise_reports()
+            if reports:
+                for report in reports:
+                    yield report
+                self.state = singer.write_bookmark(self.state, self.stream_name, 'LastUpdatedTime', strptime_to_utc(report.get('ReportDate')).isoformat())
+                singer.write_state(self.state)
 
             start_dttm = end_dttm
             end_dttm = start_dttm + timedelta(days=DATE_WINDOW_SIZE)

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import time
 from datetime import datetime as dt
 from datetime import timedelta
 
@@ -23,6 +24,12 @@ class TestQuickbooksBase(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z" # %H:%M:%SZ
+    DATETIME_FMT = {
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S.000000Z",
+        "%Y-%m-%dT%H:%M:%S%z"
+    }
 
     def setUp(self):
         missing_envs = [x for x in [
@@ -89,6 +96,7 @@ class TestQuickbooksBase(unittest.TestCase):
             "transfers",
             "vendor_credits",
             "vendors",
+            "profit_loss_report"
         }
 
     def expected_metadata(self):
@@ -96,11 +104,17 @@ class TestQuickbooksBase(unittest.TestCase):
 
         mdata = {}
         for stream in self.expected_check_streams():
-            mdata[stream] = {
-                self.PRIMARY_KEYS: {'Id'},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {'MetaData'},
-            }
+            if self.is_report_stream(stream):
+                mdata[stream] = {
+                    self.REPLICATION_METHOD: self.INCREMENTAL,
+                    self.REPLICATION_KEYS: {'ReportDate'},
+                }
+            else:
+                mdata[stream] = {
+                    self.PRIMARY_KEYS: {'Id'},
+                    self.REPLICATION_METHOD: self.INCREMENTAL,
+                    self.REPLICATION_KEYS: {'MetaData'},
+                }
 
         return mdata
 
@@ -222,3 +236,14 @@ class TestQuickbooksBase(unittest.TestCase):
         record_counts["vendors"] = 26
 
         return record_counts
+
+    def dt_to_ts(self, dtime):
+        for date_format in self.DATETIME_FMT:
+            try:
+                date_stripped = int(time.mktime(dt.strptime(dtime, date_format).timetuple()))
+                return date_stripped
+            except ValueError:
+                continue
+
+    def is_report_stream(self, stream):
+        return stream in ["profit_loss_report"]

--- a/tests/base.py
+++ b/tests/base.py
@@ -96,11 +96,8 @@ class TestQuickbooksBase(unittest.TestCase):
             "transfers",
             "vendor_credits",
             "vendors",
-<<<<<<< HEAD
-            "profit_loss_report"
-=======
+            "profit_loss_report",
             "deleted_objects"
->>>>>>> 7fa0b1c4e139280c731f6ec095a5cdbd5eca8d64
         }
 
     def expected_metadata(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -106,6 +106,7 @@ class TestQuickbooksBase(unittest.TestCase):
         for stream in self.expected_check_streams():
             if self.is_report_stream(stream):
                 mdata[stream] = {
+                    self.PRIMARY_KEYS: {'ReportDate'},
                     self.REPLICATION_METHOD: self.INCREMENTAL,
                     self.REPLICATION_KEYS: {'ReportDate'},
                 }

--- a/tests/test_quickbooks_bookmarks.py
+++ b/tests/test_quickbooks_bookmarks.py
@@ -138,20 +138,29 @@ class TestQuickbooksBookmarks(TestQuickbooksBase):
                 # Verify the second sync records respect the previous (simulated) bookmark value
                 simulated_bookmark_value = new_state['bookmarks'][stream][sub_level_replication_key]
                 for message in second_sync_messages:
-                    replication_key_value = message.get('data').get(top_level_replication_key).get(sub_level_replication_key)
-                    self.assertGreaterEqual(replication_key_value, simulated_bookmark_value,
+                    if self.is_report_stream(stream):
+                        replication_key_value = message.get('data').get('ReportDate')
+                    else:
+                        replication_key_value = message.get('data').get(top_level_replication_key).get(sub_level_replication_key)
+                    self.assertGreaterEqual(self.dt_to_ts(replication_key_value), self.dt_to_ts(simulated_bookmark_value),
                                             msg="Second sync records do not repect the previous bookmark.")
 
                 # Verify the first sync bookmark value is the max replication key value for a given stream
                 for message in first_sync_messages:
-                    replication_key_value = message.get('data').get(top_level_replication_key).get(sub_level_replication_key)
-                    self.assertLessEqual(replication_key_value, first_bookmark_value_utc,
+                    if self.is_report_stream(stream):
+                        replication_key_value = message.get('data').get('ReportDate')
+                    else:
+                        replication_key_value = message.get('data').get(top_level_replication_key).get(sub_level_replication_key)
+                    self.assertLessEqual(self.dt_to_ts(replication_key_value), self.dt_to_ts(first_bookmark_value_utc),
                                          msg="First sync bookmark was set incorrectly, a record with a greater rep key value was synced")
 
                 # Verify the second sync bookmark value is the max replication key value for a given stream
                 for message in second_sync_messages:
-                    replication_key_value = message.get('data').get(top_level_replication_key).get(sub_level_replication_key)
-                    self.assertLessEqual(replication_key_value, second_bookmark_value_utc,
+                    if self.is_report_stream(stream):
+                        replication_key_value = message.get('data').get('ReportDate')
+                    else:
+                        replication_key_value = message.get('data').get(top_level_replication_key).get(sub_level_replication_key)
+                    self.assertLessEqual(self.dt_to_ts(replication_key_value), self.dt_to_ts(second_bookmark_value_utc),
                                          msg="Second sync bookmark was set incorrectly, a record with a greater rep key value was synced")
 
                 # Verify the number of records in the 2nd sync is less then the first

--- a/tests/test_quickbooks_pagination.py
+++ b/tests/test_quickbooks_pagination.py
@@ -67,6 +67,8 @@ class TestQuickbooksPagination(TestQuickbooksBase):
 
                 sync_messages = sync_records.get(stream, {'messages': []}).get('messages')
 
+                primary_key = self.expected_primary_keys().get(stream).pop()
+
                 # Verify the sync meets or exceeds the default record count
                 self.assertLessEqual(expected_count, record_count)
 
@@ -79,12 +81,8 @@ class TestQuickbooksPagination(TestQuickbooksBase):
                 self.assertGreater(record_count, pagination_threshold,
                                    msg="Record count not large enough to gaurantee pagination.")
 
-                # ProfitAndLoss report stream doesn't have any primary key
-                if not self.is_report_stream(stream):
-                    primary_key = self.expected_primary_keys().get(stream).pop()
-
-                    # Verify we did not duplicate any records across pages
-                    records_pks_set = {message.get('data').get(primary_key) for message in sync_messages}
-                    records_pks_list = [message.get('data').get(primary_key) for message in sync_messages]
-                    self.assertCountEqual(records_pks_set, records_pks_list,
-                                        msg="We have duplicate records for {}".format(stream))
+                # Verify we did not duplicate any records across pages
+                records_pks_set = {message.get('data').get(primary_key) for message in sync_messages}
+                records_pks_list = [message.get('data').get(primary_key) for message in sync_messages]
+                self.assertCountEqual(records_pks_set, records_pks_list,
+                                      msg="We have duplicate records for {}".format(stream))

--- a/tests/test_quickbooks_pagination.py
+++ b/tests/test_quickbooks_pagination.py
@@ -67,18 +67,24 @@ class TestQuickbooksPagination(TestQuickbooksBase):
 
                 sync_messages = sync_records.get(stream, {'messages': []}).get('messages')
 
-                primary_key = self.expected_primary_keys().get(stream).pop()
-
                 # Verify the sync meets or exceeds the default record count
                 self.assertLessEqual(expected_count, record_count)
 
                 # Verify the number or records exceeds the max_results (api limit)
-                pagination_threshold = int(self.get_properties().get(page_size_key))
+                if self.is_report_stream(stream):
+                    #Tap is making API call in 30 days window for reports stream
+                    pagination_threshold = 30
+                else:
+                    pagination_threshold = int(self.get_properties().get(page_size_key))
                 self.assertGreater(record_count, pagination_threshold,
                                    msg="Record count not large enough to gaurantee pagination.")
 
-                # Verify we did not duplicate any records across pages
-                records_pks_set = {message.get('data').get(primary_key) for message in sync_messages}
-                records_pks_list = [message.get('data').get(primary_key) for message in sync_messages]
-                self.assertCountEqual(records_pks_set, records_pks_list,
-                                      msg="We have duplicate records for {}".format(stream))
+                # ProfitAndLoss report stream doesn't have any primary key
+                if not self.is_report_stream(stream):
+                    primary_key = self.expected_primary_keys().get(stream).pop()
+
+                    # Verify we did not duplicate any records across pages
+                    records_pks_set = {message.get('data').get(primary_key) for message in sync_messages}
+                    records_pks_list = [message.get('data').get(primary_key) for message in sync_messages]
+                    self.assertCountEqual(records_pks_set, records_pks_list,
+                                        msg="We have duplicate records for {}".format(stream))

--- a/tests/test_quickbooks_start_date.py
+++ b/tests/test_quickbooks_start_date.py
@@ -89,7 +89,9 @@ class TestQuickbooksStartDate(TestQuickbooksBase):
 
                 # start dates
                 start_date_1 = self.get_properties()['start_date']
+                start_date_1_epoch = self.dt_to_ts(start_date_1)
                 start_date_2 = self.get_properties(original=False)['start_date']
+                start_date_2_epoch = self.dt_to_ts(start_date_2)
 
                 # Verify by stream that our first sync meets or exceeds the default record count
                 self.assertLessEqual(expected_first_sync_count, first_sync_count)
@@ -99,10 +101,16 @@ class TestQuickbooksStartDate(TestQuickbooksBase):
 
                 # Verify by stream that all records have a rep key that is equal to or greater than that sync's start_date
                 for message in first_sync_messages:
-                    rep_key_value = message.get('data').get('MetaData').get('LastUpdatedTime')
-                    self.assertGreaterEqual(rep_key_value, start_date_1,
+                    if self.is_report_stream(stream):
+                        rep_key_value = message.get('data').get('ReportDate')
+                    else :
+                        rep_key_value = message.get('data').get('MetaData').get('LastUpdatedTime')
+                    self.assertGreaterEqual(self.dt_to_ts(rep_key_value), start_date_1_epoch,
                                             msg="A record was replicated with a replication key value prior to the start date")
                 for message in second_sync_messages:
-                    rep_key_value = message.get('data').get('MetaData').get('LastUpdatedTime')
-                    self.assertGreaterEqual(rep_key_value, start_date_2,
+                    if self.is_report_stream(stream):
+                        rep_key_value = message.get('data').get('ReportDate')
+                    else :
+                        rep_key_value = message.get('data').get('MetaData').get('LastUpdatedTime')
+                    self.assertGreaterEqual(self.dt_to_ts(rep_key_value), start_date_2_epoch,
                                             msg="A record was replicated with a replication key value prior to the start date")

--- a/tests/unittests/test_reports_parser.py
+++ b/tests/unittests/test_reports_parser.py
@@ -206,7 +206,12 @@ class TestReportsParser(unittest.TestCase):
             }
         }
 
-        expected_data = {
+        expected_data_after_parse_columns = {
+            "dates": ["2021-07-20", "2021-07-21"],
+            "data": []
+        }
+
+        expected_data_after_parse_rows = {
             "dates": ["2021-07-20", "2021-07-21"],
             "data": [{
                 "name": "Total Income",
@@ -226,6 +231,9 @@ class TestReportsParser(unittest.TestCase):
             }]
         }
 
-        reports.parse_report_metadata(response)
-        self.assertEqual(reports.parsed_metadata, expected_data)
+        reports.parse_report_columns(response['Columns'])
+        self.assertEqual(reports.parsed_metadata, expected_data_after_parse_columns)
+
+        reports.parse_report_rows(response["Rows"])
+        self.assertEqual(reports.parsed_metadata, expected_data_after_parse_rows)
     

--- a/tests/unittests/test_reports_parser.py
+++ b/tests/unittests/test_reports_parser.py
@@ -5,6 +5,9 @@ import tap_quickbooks.streams as streams
 class TestReportsParser(unittest.TestCase):
 
     def test_day_wise_reports(self):
+        """
+        Test that day wise reports are generated from formatted parsed_metadata
+        """
         reports = streams.ReportStream("", "", "")
         reports.parsed_metadata = {
             "dates": ["2021-07-01", "2021-07-02", "2021-07-03"],
@@ -41,6 +44,9 @@ class TestReportsParser(unittest.TestCase):
         self.assertListEqual(expected_records, records)
 
     def test_report_parser(self):
+        """
+        Test that metadata returned from report API is formatted in desired format
+        """
         reports = streams.ReportStream("", "", "")
 
         response = {

--- a/tests/unittests/test_reports_parser.py
+++ b/tests/unittests/test_reports_parser.py
@@ -1,0 +1,225 @@
+import unittest
+import tap_quickbooks.streams as streams
+
+
+class TestReportsParser(unittest.TestCase):
+
+    def test_day_wise_reports(self):
+        reports = streams.ReportStream("", "", "")
+        reports.parsed_metadata = {
+            "dates": ["2021-07-01", "2021-07-02", "2021-07-03"],
+            "data": [
+                {
+                    "name": "Total Income",
+                    "values": ["4.00", "5.00", "6.00", "15.00"]
+                }, {
+                    "name": "Gross Profit",
+                    "values": ["3.00", "4.00", "5.00", "12.00"]
+                }
+            ]
+        }
+
+        expected_records = [
+            {
+                "ReportDate": "2021-07-01",
+                "AccountingMethod": "Accrual",
+                "Details": {"Total Income": "4.00", "Gross Profit": "3.00"}
+            },
+            {
+                "ReportDate": "2021-07-02",
+                "AccountingMethod": "Accrual",
+                "Details": {"Total Income": "5.00", "Gross Profit": "4.00"}
+            },
+            {
+                "ReportDate": "2021-07-03",
+                "AccountingMethod": "Accrual",
+                "Details": {"Total Income": "6.00", "Gross Profit": "5.00"}
+            }
+        ]
+
+        records = list(reports.day_wise_reports())
+        self.assertListEqual(expected_records, records)
+
+    def test_report_parser(self):
+        reports = streams.ReportStream("", "", "")
+
+        response = {
+            "Header": {
+                "Time": "2021-07-22T05:51:37-07:00",
+                "ReportName": "ProfitAndLoss",
+                "ReportBasis": "Accrual",
+                "StartPeriod": "2021-07-20",
+                "EndPeriod": "2021-07-21",
+                "SummarizeColumnsBy": "Days",
+                "Currency": "USD",
+                "Option": [{
+                    "Name": "AccountingStandard",
+                    "Value": "GAAP"
+                }, {
+                    "Name": "NoReportData",
+                    "Value": "true"
+                }]
+            },
+            "Columns": {
+                "Column": [{
+                    "ColTitle": "",
+                    "ColType": "Account",
+                    "MetaData": [{
+                        "Name": "ColKey",
+                        "Value": "account"
+                    }]
+                }, {
+                    "ColTitle": "Jul 20, 2021",
+                    "ColType": "Money",
+                    "MetaData": [{
+                        "Name": "StartDate",
+                        "Value": "2021-07-20"
+                    }, {
+                        "Name": "EndDate",
+                        "Value": "2021-07-20"
+                    }, {
+                        "Name": "ColKey",
+                        "Value": "Jul 20, 2021"
+                    }]
+                }, {
+                    "ColTitle": "Jul 21, 2021",
+                    "ColType": "Money",
+                    "MetaData": [{
+                        "Name": "StartDate",
+                        "Value": "2021-07-21"
+                    }, {
+                        "Name": "EndDate",
+                        "Value": "2021-07-21"
+                    }, {
+                        "Name": "ColKey",
+                        "Value": "Jul 21, 2021"
+                    }]
+                }, {
+                    "ColTitle": "Total",
+                    "ColType": "Money",
+                    "MetaData": [{
+                        "Name": "ColKey",
+                        "Value": "total"
+                    }]
+                }]
+            },
+            "Rows": {
+                "Row": [{
+                    "Header": {
+                        "ColData": [{
+                            "value": "Income"
+                        }, {
+                            "value": ""
+                        }, {
+                            "value": ""
+                        }, {
+                            "value": ""
+                        }]
+                    },
+                    "Summary": {
+                        "ColData": [{
+                            "value": "Total Income"
+                        }, {
+                            "value": ""
+                        }, {
+                            "value": ""
+                        }, {
+                            "value": "0.00"
+                        }]
+                    },
+                    "type": "Section",
+                    "group": "Income"
+                }, {
+                    "Summary": {
+                        "ColData": [{
+                            "value": "Gross Profit"
+                        }, {
+                            "value": "0.00"
+                        }, {
+                            "value": "0.00"
+                        }, {
+                            "value": "0.00"
+                        }]
+                    },
+                    "type": "Section",
+                    "group": "GrossProfit"
+                }, {
+                    "Header": {
+                        "ColData": [{
+                            "value": "Expenses"
+                        }, {
+                            "value": ""
+                        }, {
+                            "value": ""
+                        }, {
+                            "value": ""
+                        }]
+                    },
+                    "Summary": {
+                        "ColData": [{
+                            "value": "Total Expenses"
+                        }, {
+                            "value": ""
+                        }, {
+                            "value": ""
+                        }, {
+                            "value": "0.00"
+                        }]
+                    },
+                    "type": "Section",
+                    "group": "Expenses"
+                }, {
+                    "Summary": {
+                        "ColData": [{
+                            "value": "Net Operating Income"
+                        }, {
+                            "value": "0.00"
+                        }, {
+                            "value": "0.00"
+                        }, {
+                            "value": "0.00"
+                        }]
+                    },
+                    "type": "Section",
+                    "group": "NetOperatingIncome"
+                }, {
+                    "Summary": {
+                        "ColData": [{
+                            "value": "Net Income"
+                        }, {
+                            "value": "0.00"
+                        }, {
+                            "value": "0.00"
+                        }, {
+                            "value": "0.00"
+                        }]
+                    },
+                    "type": "Section",
+                    "group": "NetIncome"
+                }]
+            }
+        }
+
+        expected_data = {
+            "dates": ["2021-07-20", "2021-07-21"],
+            "data": [{
+                "name": "Total Income",
+                "values": ["", "", "0.00"]
+            }, {
+                "name": "Gross Profit",
+                "values": ["0.00", "0.00", "0.00"]
+            }, {
+                "name": "Total Expenses",
+                "values": ["", "", "0.00"]
+            }, {
+                "name": "Net Operating Income",
+                "values": ["0.00", "0.00", "0.00"]
+            }, {
+                "name": "Net Income",
+                "values": ["0.00", "0.00", "0.00"]
+            }]
+        }
+
+        reports.parse_report_metadata(response)
+        self.assertEqual(reports.parsed_metadata, expected_data)
+    


### PR DESCRIPTION
# Description of change
TDL-13967: Add ProfitAndLoss report stream

Finalized approach:
- Fetch records for a minimum of 30 days if the bookmark is used from the state in sync.
  - If the bookmark is more than 30 days away then fetch all records up to the current day.
  - If the bookmark is less than 30 days away then fetch records for the last 30 days.
- Fetch records from start date to current date if the start date is used in sync.
- Bookmark is required so consider it as an INCREMENTAL stream.
- Consider ‘ReportDate’ as a primary key and replication key.
- Only consider _Accrual_ accounting method for the report as of now.

# Manual QA steps
 - Verified that record for every day is emitted from the start date to the current date in the start date scenario.
 - Verified that a minimum 30-day record is emitted if a bookmark from the state is used.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch