### PR TITLE
Changing manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include tap_quickbooks/schemas/*.json
+include tap_quickbooks/schemas/shared/*.json


### PR DESCRIPTION
# Description of change
The manifest file change it to fix the issue we found after deploying quickbooks. There was a new shared directory that got created as part of schema changes. 

Here is the error:
[Errno 2] No such file or directory: '/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_quickbooks/schemas/shared'

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
