### PR TITLE
TDL-20058: Add missing integration tests.

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -20,9 +20,7 @@ class TestQuickbooksBase(unittest.TestCase):
     PRIMARY_KEYS = "table-key-properties"
     FOREIGN_KEYS = "table-foreign-key-properties"
     REPLICATION_METHOD = "forced-replication-method"
-    API_LIMIT = "max-row-limit"
     INCREMENTAL = "INCREMENTAL"
-    FULL = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z" # %H:%M:%SZ
     # list of streams which supports custom field
     custom_command_streams = ['invoices','estimates','credit_memos','refund_receipts','sales_receipts','purchase_orders']

--- a/tests/test_quickbooks_all_fields.py
+++ b/tests/test_quickbooks_all_fields.py
@@ -2,6 +2,7 @@ from tap_tester import runner, menagerie
 from base import TestQuickbooksBase
 
 class TestQuickbooksAllFields(TestQuickbooksBase):
+    """Test case to verify we are replicating all fields data from the Tap"""
 
     # remove fields that are replicated when you have account for that specific reqion
     locale_fields = {

--- a/tests/test_quickbooks_automatic_fields.py
+++ b/tests/test_quickbooks_automatic_fields.py
@@ -76,11 +76,11 @@ class TestQuickbooksAutomaticFields(TestQuickbooksBase):
 
         # Get records that reached the target
         sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_check_streams(), self.expected_primary_keys())
+            self, conn_id, expected_streams, self.expected_primary_keys())
         synced_records = runner.get_records_from_target_output()
 
         # Assert the records for each stream
-        for stream in self.expected_check_streams():
+        for stream in expected_streams:
             with self.subTest(stream=stream):
                 expected_primary_keys = self.expected_primary_keys()[stream]
                 expected_keys = self.expected_automatic_fields().get(stream)

--- a/tests/test_quickbooks_automatic_fields.py
+++ b/tests/test_quickbooks_automatic_fields.py
@@ -8,6 +8,8 @@ from base import TestQuickbooksBase
 page_size_key = 'max_results'
 
 class TestQuickbooksAutomaticFields(TestQuickbooksBase):
+    """Test case to verify we are replicating automatic fields data when all the fields are not selected"""
+
     def name(self):
         return "tap_tester_quickbooks_combined_test"
 

--- a/tests/test_quickbooks_automatic_fields.py
+++ b/tests/test_quickbooks_automatic_fields.py
@@ -29,15 +29,6 @@ class TestQuickbooksAutomaticFields(TestQuickbooksBase):
             page_size_key: '10'
         }
 
-    def expected_streams(self):
-        """
-        All streams are under test with the exception of 'budgets' which
-        has a workaround to skip the invalid assertion. See if block in
-        test_run for details
-        """
-        return self.expected_check_streams()
-
-
     def test_run(self):
         conn_id = self.ensure_connection()
 
@@ -52,7 +43,7 @@ class TestQuickbooksAutomaticFields(TestQuickbooksBase):
         self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
 
         # Select only the expected streams tables
-        expected_streams = self.expected_streams()
+        expected_streams = self.expected_check_streams()
         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
         self.select_all_streams_and_fields(conn_id, catalog_entries, False)
 
@@ -83,11 +74,11 @@ class TestQuickbooksAutomaticFields(TestQuickbooksBase):
 
         # Get records that reached the target
         sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+            self, conn_id, self.expected_check_streams(), self.expected_primary_keys())
         synced_records = runner.get_records_from_target_output()
 
         # Assert the records for each stream
-        for stream in self.expected_streams():
+        for stream in self.expected_check_streams():
             with self.subTest(stream=stream):
                 expected_primary_keys = self.expected_primary_keys()[stream]
                 expected_keys = self.expected_automatic_fields().get(stream)

--- a/tests/test_quickbooks_bookmarks.py
+++ b/tests/test_quickbooks_bookmarks.py
@@ -73,7 +73,7 @@ class TestQuickbooksBookmarks(TestQuickbooksBase):
         sync_job_name = runner.run_sync_mode(self, conn_id)
         first_sync_records = runner.get_records_from_target_output()
         first_sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+            self, conn_id, expected_streams, self.expected_primary_keys())
         first_sync_bookmarks = menagerie.get_state(conn_id)
 
         # Verify tap and target exit codes
@@ -90,7 +90,7 @@ class TestQuickbooksBookmarks(TestQuickbooksBase):
         sync_job_name = runner.run_sync_mode(self, conn_id)
         second_sync_records = runner.get_records_from_target_output()
         second_sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+            self, conn_id, expected_streams, self.expected_primary_keys())
         second_sync_bookmarks = menagerie.get_state(conn_id)
 
         # Verify tap and target exit codes
@@ -98,7 +98,7 @@ class TestQuickbooksBookmarks(TestQuickbooksBase):
         menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
 
         # Test by stream
-        for stream in self.expected_streams():
+        for stream in expected_streams:
             with self.subTest(stream=stream):
                 # record counts
                 first_sync_count = first_sync_record_count.get(stream, 0)

--- a/tests/test_quickbooks_bookmarks.py
+++ b/tests/test_quickbooks_bookmarks.py
@@ -14,9 +14,7 @@ class TestQuickbooksBookmarks(TestQuickbooksBase):
         return "tap_tester_quickbooks_combined_test"
 
     def expected_streams(self):
-        return self.expected_check_streams().difference({
-            'budgets'
-        })
+        return self.expected_check_streams().difference({'budgets'})
 
     def convert_state_to_utc(self, date_str):
         """

--- a/tests/test_quickbooks_bookmarks.py
+++ b/tests/test_quickbooks_bookmarks.py
@@ -10,6 +10,8 @@ from base import TestQuickbooksBase
 
 
 class TestQuickbooksBookmarks(TestQuickbooksBase):
+    """Test case to verify the Tap is writing bookmark as expectation"""
+
     def name(self):
         return "tap_tester_quickbooks_combined_test"
 

--- a/tests/test_quickbooks_discovery.py
+++ b/tests/test_quickbooks_discovery.py
@@ -14,6 +14,7 @@ class TestQuickbooksDiscovery(TestQuickbooksBase):
     def test_run(self):
         conn_id = self.ensure_connection()
 
+        expected_streams = self.expected_check_streams()
         #run in check mode
         check_job_name = runner.run_check_mode(self, conn_id)
 
@@ -24,16 +25,16 @@ class TestQuickbooksDiscovery(TestQuickbooksBase):
         found_catalogs = menagerie.get_catalogs(conn_id)
         self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
         self.assertEqual(len(found_catalogs),
-                         len(self.expected_check_streams()),
+                         len(expected_streams),
                          msg="Expected {} streams, actual was {} for connection {},"
                          " actual {}".format(
-                             len(self.expected_check_streams()),
+                             len(expected_streams),
                              len(found_catalogs),
                              found_catalogs,
                              conn_id))
 
         found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
-        self.assertEqual(set(self.expected_check_streams()),
+        self.assertEqual(set(expected_streams),
                          set(found_catalog_names),
                          msg="Expected streams don't match actual streams")
 
@@ -42,7 +43,7 @@ class TestQuickbooksDiscovery(TestQuickbooksBase):
         self.assertTrue(all([re.fullmatch(r"[a-z_]+", name) for name in found_catalog_names]),
                         msg="One or more streams don't follow standard naming")
 
-        diff = self.expected_check_streams().symmetric_difference(found_catalog_names)
+        diff = expected_streams.symmetric_difference(found_catalog_names)
         self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
         print("discovered schemas are OK")
 

--- a/tests/test_quickbooks_discovery.py
+++ b/tests/test_quickbooks_discovery.py
@@ -85,16 +85,10 @@ class TestQuickbooksDiscovery(TestQuickbooksBase):
                 # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
                 actual_replication_method = stream_properties[0].get(
                     "metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
-                if stream_properties[0].get(
-                        "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS, []):
 
-                    self.assertTrue(actual_replication_method == self.INCREMENTAL,
-                                    msg="Expected INCREMENTAL replication "
-                                        "since there is a replication key")
-                else:
-                    self.assertTrue(actual_replication_method == self.FULL,
-                                    msg="Expected FULL replication "
-                                        "since there is no replication key")
+                self.assertTrue(actual_replication_method == self.INCREMENTAL,
+                                msg="Expected INCREMENTAL replication "
+                                    "since there is a replication key")
 
                 # verify the actual replication matches our expected replication method
                 self.assertEqual(

--- a/tests/test_quickbooks_discovery.py
+++ b/tests/test_quickbooks_discovery.py
@@ -160,3 +160,11 @@ class TestQuickbooksDiscovery(TestQuickbooksBase):
                     custom_field_stream_count += 1
                     
         self.assertEqual(custom_field_stream_count,6)
+
+        actual_fields = []
+        for md_entry in metadata:
+            if md_entry['breadcrumb'] != []:
+                actual_fields.append(md_entry['breadcrumb'][1])
+
+        # Verify there is no duplicate metadata entries
+        self.assertEqual(len(actual_fields), len(set(actual_fields)), msg = "duplicates in the metadata entries retrieved")

--- a/tests/test_quickbooks_discovery.py
+++ b/tests/test_quickbooks_discovery.py
@@ -6,6 +6,8 @@ import re
 from base import TestQuickbooksBase
 
 class TestQuickbooksDiscovery(TestQuickbooksBase):
+    """Test case to verify the Tap is creating the catalog file as expected"""
+
     def name(self):
         return "tap_tester_quickbooks_combined_test"
 

--- a/tests/test_quickbooks_pagination.py
+++ b/tests/test_quickbooks_pagination.py
@@ -7,6 +7,8 @@ from base import TestQuickbooksBase
 page_size_key = 'max_results'
 
 class TestQuickbooksPagination(TestQuickbooksBase):
+    """Test case to verify the pagination is working as expected"""
+
     def name(self):
         return "tap_tester_quickbooks_combined_test"
 

--- a/tests/test_quickbooks_pagination.py
+++ b/tests/test_quickbooks_pagination.py
@@ -56,10 +56,10 @@ class TestQuickbooksPagination(TestQuickbooksBase):
         # Examine target file
         sync_records = runner.get_records_from_target_output()
         sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+            self, conn_id, expected_streams, self.expected_primary_keys())
 
         # Test by stream
-        for stream in self.expected_streams():
+        for stream in expected_streams:
             if stream == "deleted_objects": # Deleted Objects stream does not have Pagination support
                 continue
             with self.subTest(stream=stream):

--- a/tests/test_quickbooks_pagination.py
+++ b/tests/test_quickbooks_pagination.py
@@ -16,9 +16,7 @@ class TestQuickbooksPagination(TestQuickbooksBase):
         returns a single record of the current budget state and will never exceed
         our pagination size (max_results) for this test.
         """
-        return self.expected_check_streams().difference({
-            'budgets'
-        })
+        return self.expected_check_streams().difference({'budgets'})
 
     def get_properties(self):
         return {

--- a/tests/test_quickbooks_start_date.py
+++ b/tests/test_quickbooks_start_date.py
@@ -50,7 +50,7 @@ class TestQuickbooksStartDate(TestQuickbooksBase):
         sync_job_name = runner.run_sync_mode(self, conn_id)
         first_sync_records = runner.get_records_from_target_output()
         first_sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+            self, conn_id, expected_streams, self.expected_primary_keys())
 
         # Verify tap and target exit codes
         exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
@@ -71,14 +71,14 @@ class TestQuickbooksStartDate(TestQuickbooksBase):
         sync_job_name = runner.run_sync_mode(self, conn_id)
         second_sync_records = runner.get_records_from_target_output()
         second_sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+            self, conn_id, expected_streams, self.expected_primary_keys())
 
         # Verify tap and target exit codes
         exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
         menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
 
         # Test by stream
-        for stream in self.expected_streams():
+        for stream in expected_streams:
             with self.subTest(stream=stream):
                 # record counts
                 first_sync_count = first_sync_record_count.get(stream, 0)

--- a/tests/test_quickbooks_start_date.py
+++ b/tests/test_quickbooks_start_date.py
@@ -5,6 +5,8 @@ import tap_tester.runner      as runner
 from base import TestQuickbooksBase
 
 class TestQuickbooksStartDate(TestQuickbooksBase):
+    """Test case to verify the Tap respected the start date provided in the config"""
+
     def name(self):
         return "tap_tester_quickbooks_combined_test"
 

--- a/tests/test_quickbooks_sync_all.py
+++ b/tests/test_quickbooks_sync_all.py
@@ -6,6 +6,8 @@ import re
 from base import TestQuickbooksBase
 
 class TestQuickbooksSyncAll(TestQuickbooksBase):
+    """Test case to verify the working of the Tap"""
+
     def name(self):
         return "tap_tester_quickbooks_combined_test"
 

--- a/tests/test_quickbooks_sync_all.py
+++ b/tests/test_quickbooks_sync_all.py
@@ -14,6 +14,7 @@ class TestQuickbooksSyncAll(TestQuickbooksBase):
     def test_run(self):
         conn_id = self.ensure_connection()
 
+        expected_streams = self.expected_streams()
         # Run in check mode
         check_job_name = runner.run_check_mode(self, conn_id)
 
@@ -36,10 +37,10 @@ class TestQuickbooksSyncAll(TestQuickbooksBase):
 
         # Verify actual rows were synced
         sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+            self, conn_id, expected_streams, self.expected_primary_keys())
 
         # Examine target output
-        for stream in self.expected_streams():
+        for stream in expected_streams:
             with self.subTest(stream=stream):
                 # Each stream should have 1 or more records returned
                 self.assertGreaterEqual(sync_record_count[stream], 1)


### PR DESCRIPTION
# Description of change
[TDL-20058](https://jira.talendforge.org/browse/TDL-20058): Add missing tap-tester tests
- Added missing assertions in the below tests
  - Automatic fields test
  - Discovery test
  - Start Date test
 
 NOTE: The interrupted sync test is added as part of [TDL-20059](https://jira.talendforge.org/browse/TDL-20059) & [PR#55](https://github.com/singer-io/tap-quickbooks/pull/55)  because currently_sycing was not working as expected.

# Manual QA steps
 - The build is passing successfully.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
