### PR TITLE
Increase Date Window Size for ReportStream

### DIFF
--- a/tap_quickbooks/streams.py
+++ b/tap_quickbooks/streams.py
@@ -6,7 +6,7 @@ from singer.utils import strptime_to_utc
 
 import tap_quickbooks.query_builder as query_builder
 
-DATE_WINDOW_SIZE = 29
+DATE_WINDOW_SIZE = 59
 
 class Stream:
     endpoint = '/v3/company/{realm_id}/query'


### PR DESCRIPTION
The date window Size for ReportsStream is too narrow to pick up operational changes from month-closing processes, specifically when using the `ProfitAndLossReport`.

This is an issue that is only present when you try to put the connector into practice.

Description of Issue: 
- Sync runs ProfitAndLossReport on March 8th
   - ProfitAndLossReport pulled for 30 days, (2023-02-06 - 2023-03-08)
   - However, on March 8th an adjustment to posting for 2023-02-01 was made, as month closing will often modify account balances at beginning of prior period month.
   - ProfitAndLossReport totals are recognized as the sum of daily balances between 2023-02-01 - 2023-02-28, with a row output for each day.
   - This leads to continuous misalignment between what the sync reports as ProfitAndLossReport and actuals, as the stream is not picking up updates to the prior period ProfitAndLossReport during the monthly closing process.
   - As a result, stream history needs to be reset and run manually each month to capture changes against the prior month.

Proposed Solution:
- Extend reporting window to capture 2 months (60 days) worth of report history, giving accounting teams the full month to close books on the prior period.

# Description of change
(write a short description or paste a link to JIRA)
Extend reporting window to capture 2 months (60 days) worth of report history, giving accounting teams the full month to close books on the prior period.

# Manual QA steps
 - 
 
# Risks
 - Increased load to Quickbooks API, Systems. 
 
# Rollback steps
 - revert this branch
