### PR TITLE
changes to handle 429 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.2.0
+
+   * Revise backoff logic to handle 429 error [#72](https://github.com/singer-io/tap-quickbooks/pull/72)
+
 ## 2.1.0
 
    * Add support for dev mode [#64](https://github.com/singer-io/tap-quickbooks/pull/64)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-quickbooks',
-      version='2.1.0',
+      version='2.2.0',
       description='Singer.io tap for extracting data from the Quickbooks API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_quickbooks/client.py
+++ b/tap_quickbooks/client.py
@@ -191,15 +191,12 @@ class QuickbooksClient():
 
     @backoff.on_exception(backoff.expo, Timeout, max_tries=5, factor=2)
     @backoff.on_exception(backoff.constant,
-                        (Quickbooks5XXException,
-                        Quickbooks4XXException,
-                        requests.ConnectionError),
-                        max_tries=3,
-                        interval=10)
-    @backoff.on_exception(backoff.constant,
-                        QuickbooksTooManyRequestsError,
-                        max_tries=5,
-                        interval=60)
+                          (QuickbooksTooManyRequestsError,
+                           Quickbooks5XXException,
+                           Quickbooks4XXException,
+                           requests.ConnectionError),
+                          max_tries=3,
+                          interval=60)
     @singer.utils.ratelimit(495, 60)
     def _make_request(self, method, endpoint, headers=None, params=None, data=None):
         # Sandbox requests need to be made against the Sandbox endpoint base

--- a/tests/test_quickbooks_all_fields.py
+++ b/tests/test_quickbooks_all_fields.py
@@ -192,7 +192,7 @@ class TestQuickbooksAllFields(TestQuickbooksBase):
         - Verify no unexpected streams were replicated
         - Verify that more than just the automatic fields are replicated for each stream
         """
-        expected_streams = self.expected_check_streams()
+        expected_streams = self.expected_check_streams() - {'deleted_objects'}
 
         # instantiate connection
         conn_id = self.ensure_connection()

--- a/tests/test_quickbooks_all_fields.py
+++ b/tests/test_quickbooks_all_fields.py
@@ -125,16 +125,13 @@ class TestQuickbooksAllFields(TestQuickbooksBase):
             'PurchaseTaxCodeRef', 'SalesTaxCodeRef', 'SalesTaxIncluded', 'PurchaseTaxIncluded'
         ],
         'purchase_orders': [
-            'ShipTo', 'RecurDataRef', 'DueDate', 'SalesTermRef', 'ClassRef', 'TxnTaxDetail'
+            'ShipTo', 'DueDate', 'SalesTermRef', 'ClassRef', 'TxnTaxDetail'
         ],
         'deposits': [
             'RecurDataRef', 'TxnSource',
         ],
         'journal_entries': [
             'RecurDataRef', 'TaxRateRef'
-        ],
-        'bills': [
-            'RecurDataRef'
         ],
         'tax_rates': [
             'EffectiveTaxRate'
@@ -161,7 +158,7 @@ class TestQuickbooksAllFields(TestQuickbooksBase):
             'CreditCardPayment', 'TaxExemptionRef', 'TxnSource'
         ],
         'sales_receipts': [
-            'RecurDataRef', 'TxnSource'
+            'TxnSource'
         ],
         'bill_payments': [
             'ProcessBillPayment', 'PrivateNote'
@@ -176,13 +173,10 @@ class TestQuickbooksAllFields(TestQuickbooksBase):
             'RecurDataRef', 'PaymentMethodRef', 'SalesTermRef'
         ],
         'invoices': [
-            'InvoiceLink', 'RecurDataRef', 'TxnSource'
+            'InvoiceLink', 'TxnSource'
         ],
         'employees': [
             'Organization'
-        ],
-        'transfers': [
-            'RecurDataRef'
         ]
     }
 

--- a/tests/test_quickbooks_all_fields.py
+++ b/tests/test_quickbooks_all_fields.py
@@ -186,6 +186,7 @@ class TestQuickbooksAllFields(TestQuickbooksBase):
         - Verify no unexpected streams were replicated
         - Verify that more than just the automatic fields are replicated for each stream
         """
+        # Skipping stream deleted_objects due to data unavailability
         expected_streams = self.expected_check_streams() - {'deleted_objects'}
 
         # instantiate connection

--- a/tests/test_quickbooks_automatic_fields.py
+++ b/tests/test_quickbooks_automatic_fields.py
@@ -47,6 +47,7 @@ class TestQuickbooksAutomaticFields(TestQuickbooksBase):
         self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
 
         # Select only the expected streams tables
+        # Skipping stream deleted_objects due to data unavailability
         expected_streams = self.expected_check_streams() - {'deleted_objects'}
         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
         self.select_all_streams_and_fields(conn_id, catalog_entries, False)

--- a/tests/test_quickbooks_automatic_fields.py
+++ b/tests/test_quickbooks_automatic_fields.py
@@ -47,7 +47,7 @@ class TestQuickbooksAutomaticFields(TestQuickbooksBase):
         self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
 
         # Select only the expected streams tables
-        expected_streams = self.expected_check_streams()
+        expected_streams = self.expected_check_streams() - {'deleted_objects'}
         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
         self.select_all_streams_and_fields(conn_id, catalog_entries, False)
 

--- a/tests/test_quickbooks_bookmarks.py
+++ b/tests/test_quickbooks_bookmarks.py
@@ -12,6 +12,7 @@ from base import TestQuickbooksBase
 class TestQuickbooksBookmarks(TestQuickbooksBase):
 
     def expected_streams(self):
+        # Skipping stream deleted_objects due to data unavailability
         return self.expected_check_streams().difference({'budgets', 'deleted_objects'})
 
     def calculated_states_by_stream(self, current_state):

--- a/tests/test_quickbooks_bookmarks.py
+++ b/tests/test_quickbooks_bookmarks.py
@@ -12,7 +12,7 @@ from base import TestQuickbooksBase
 class TestQuickbooksBookmarks(TestQuickbooksBase):
 
     def expected_streams(self):
-        return self.expected_check_streams().difference({'budgets'})
+        return self.expected_check_streams().difference({'budgets', 'deleted_objects'})
 
     def calculated_states_by_stream(self, current_state):
         """

--- a/tests/test_quickbooks_start_date.py
+++ b/tests/test_quickbooks_start_date.py
@@ -8,6 +8,7 @@ class TestQuickbooksStartDate(TestQuickbooksBase):
 
     def expected_streams(self):
         """All streams are under test"""
+        # Skipping stream deleted_objects due to data unavailability
         return self.expected_check_streams().difference({'deleted_objects'})
 
     def get_properties(self, original=True):

--- a/tests/test_quickbooks_start_date.py
+++ b/tests/test_quickbooks_start_date.py
@@ -8,7 +8,7 @@ class TestQuickbooksStartDate(TestQuickbooksBase):
 
     def expected_streams(self):
         """All streams are under test"""
-        return self.expected_check_streams()
+        return self.expected_check_streams().difference({'deleted_objects'})
 
     def get_properties(self, original=True):
         if original:

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -3,7 +3,8 @@ from unittest import mock
 from parameterized import parameterized
 from requests.exceptions import Timeout, ConnectionError
 from tap_quickbooks.client import Quickbooks4XXException, QuickbooksClient, Quickbooks5XXException,\
-    QuickbooksClient, QuickbooksBadRequestError, QuickbooksAuthenticationError, QuickbooksForbiddenError, QuickbooksNotFoundError, QuickbooksInternalServerError, QuickbooksServiceUnavailableError
+    QuickbooksClient, QuickbooksBadRequestError, QuickbooksAuthenticationError, QuickbooksForbiddenError,\
+    QuickbooksNotFoundError, QuickbooksTooManyRequestsError, QuickbooksInternalServerError, QuickbooksServiceUnavailableError
 from test_exception_handling import get_response
 
 class TestBackoffOAuth2SessionInitialization(unittest.TestCase):
@@ -22,6 +23,7 @@ class TestBackoffOAuth2SessionInitialization(unittest.TestCase):
         ['quickbooks_402_exception', [402, Quickbooks4XXException], [False, 3]],
         ['quickbooks_403_exception', [403, QuickbooksForbiddenError], [True, 3]],
         ['quickbooks_404_exception', [404, QuickbooksNotFoundError], [False, 3]],
+        ['quickbooks_429_exception', [429, QuickbooksTooManyRequestsError], [False, 3]],
         ['quickbooks_500_exception', [500, QuickbooksInternalServerError], [False, 3]],
         ['quickbooks_502_exception', [502, Quickbooks5XXException], [False, 3]],
         ['quickbooks_503_exception', [503, QuickbooksServiceUnavailableError], [False, 3]],
@@ -58,6 +60,7 @@ class TestBackoffOAuth2SessionInitialization(unittest.TestCase):
         ['quickbooks_402_exception', [402, Quickbooks4XXException], 3],
         ['quickbooks_403_exception', [403, QuickbooksForbiddenError], 3],
         ['quickbooks_404_exception', [404, QuickbooksNotFoundError], 3],
+        ['quickbooks_429_exception', [429, QuickbooksTooManyRequestsError], 3],
         ['quickbooks_500_exception', [500, QuickbooksInternalServerError], 3],
         ['quickbooks_502_exception', [502, Quickbooks5XXException], 3],
         ['quickbooks_503_exception', [503, QuickbooksServiceUnavailableError], 3],


### PR DESCRIPTION
# Description of change
As per the doc([link](https://developer.intuit.com/app/developer/qbo/docs/learn/rest-api-features#limits-and-throttles)), Quickbooks is going to enforce the throttling limit if Online API exceeds 500 requests per minute, per realm ID. Hence, this PR revises the backoff logic to handle too many requests error(status code:429)

# Manual QA steps
 - 
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
